### PR TITLE
Editions feature comparison

### DIFF
--- a/.vuepress/components/CheckMark.vue
+++ b/.vuepress/components/CheckMark.vue
@@ -1,0 +1,33 @@
+<template>
+  <svg
+    :aria-hidden="label ? false : true"
+    :aria-label="label"
+    :width="width"
+    :height="height"
+    viewBox="0 0 512 512"
+    fill="#27AB83"
+  >
+    <path
+      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+    ></path>
+  </svg>
+</template>
+
+<script>
+export default {
+  props: {
+    label: {
+      type: String,
+      required: false
+    },
+    width: {
+      type: Number,
+      default: 18
+    },
+    height: {
+      type: Number,
+      default: 18
+    }
+  }
+};
+</script>

--- a/.vuepress/components/EditionComparison.vue
+++ b/.vuepress/components/EditionComparison.vue
@@ -1,0 +1,197 @@
+<template>
+  <table>
+    <tbody>
+      <fragment v-for="(feature, index) in features" :key="index">
+        <tr v-if="feature.category" class="category">
+          <td class="feature">
+            <b>{{ feature.category }}</b>
+          </td>
+          <td class="edition">Lite</td>
+          <td class="edition">Pro</td>
+        </tr>
+        <tr v-for="item in feature.items" :key="item.name">
+          <td>
+            <span>{{ item.name }}</span>
+            <info-hud v-if="item.info" class="info"
+              ><span class="smaller">{{ item.info }}</span></info-hud
+            >
+          </td>
+          <td class="support">
+            <check-mark v-if="item.lite" label="supported in Commerce Lite" />
+          </td>
+          <td class="support">
+            <check-mark v-if="item.pro" label="supported in Commerce Pro" />
+          </td>
+        </tr>
+      </fragment>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import CheckMark from "./CheckMark";
+import InfoHud from "./InfoHud";
+import { Fragment } from "vue-fragment";
+
+export default {
+  components: { Fragment, CheckMark, InfoHud },
+  data() {
+    return {
+      features: [
+        {
+          category: "Checkout",
+          items: [
+            {
+              name: "Front end cart",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Add products/purchasables to cart",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Attach arbitrary data to line items",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Update line item quantity",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Add multiple line items to cart",
+              pro: true
+            }
+          ]
+        },
+        {
+          category: "Promotions",
+          items: [
+            {
+              name: "Sales",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Discounts",
+              info:
+                "Custom rules that can reduce the price of items in the cart based on things like minimum order quantity or price.",
+              pro: true
+            },
+            {
+              name: "Coupon codes",
+              pro: true
+            }
+          ]
+        },
+        {
+          category: "Shipping",
+          items: [
+            {
+              name: "Single shipping cost+price for orders",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Unlimited shipping methods, categories, and zones",
+              info: "Any shipping method may include complex shipping rules.",
+              pro: true
+            },
+            {
+              name: "Customer shipping method selection",
+              pro: true
+            }
+          ]
+        },
+        {
+          category: "Taxes",
+          items: [
+            {
+              name: "Single tax rate for all orders",
+              lite: true,
+              pro: true
+            },
+            {
+              name: "Unlimited tax categories and zones",
+              info:
+                "Custom tax rules based on configurable multi-state or multi-country zones.",
+              pro: true
+            },
+            {
+              name: "VAT Business ID validation for tax rates",
+              pro: true
+            }
+          ]
+        },
+        {
+          category: "Orders",
+          items: [
+            {
+              name: "Create orders in the control panel",
+              pro: true
+            },
+            {
+              name:
+                "Custom PHP adjusters for modifying tax, shipping, and discounts",
+              pro: true
+            }
+          ]
+        }
+      ]
+    };
+  }
+};
+</script>
+
+<style>
+table {
+  display: table;
+  border: 0;
+  width: 100%;
+  position: relative;
+  overflow: visible;
+}
+
+td,
+tr {
+  border: 0;
+}
+
+.category {
+  border-top: 0;
+  font-weight: bold;
+}
+
+.category .feature {
+  font-size: 1.25rem;
+  padding-left: 0;
+}
+
+.category td {
+  padding-top: 2rem;
+  border: 0;
+}
+
+.edition {
+  width: 15%;
+  text-align: left;
+}
+
+.support {
+  position: relative;
+  overflow: visible;
+  font-weight: bold;
+}
+
+.info {
+  margin-left: 0.75rem;
+}
+
+.smaller {
+  font-size: 0.9rem;
+  line-height: 1.25rem;
+}
+</style>

--- a/.vuepress/components/InfoHud.vue
+++ b/.vuepress/components/InfoHud.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="info-hud">
+    <v-popover placement="right">
+      <svg class="info-circle" viewBox="0 0 512 512">
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        ></path>
+      </svg>
+      <template slot="popover">
+        <slot></slot>
+      </template>
+    </v-popover>
+  </div>
+</template>
+
+<script>
+// https://github.com/craftcms/cms/blob/37e3e20d9c8096d5489e16ebe0f9a46ae3eb5808/src/web/assets/pluginstore/src/js/components/InfoHud.vue
+
+import Vue from "vue";
+import VTooltip from "v-tooltip";
+
+Vue.use(VTooltip);
+VTooltip.options.autoHide = false;
+
+export default {};
+</script>
+
+<style>
+/* https://github.com/craftcms/cms/blob/develop/lib/craftcms-sass/_mixins.scss */
+
+.info-hud {
+  display: inline-block;
+}
+
+.info-hud .v-popover {
+  color: #b8c2cc;
+  display: inline-block;
+  line-height: 0;
+
+  /* & > span {
+    outline: none;
+  } */
+}
+
+.info-hud .v-popover:hover,
+.info-hud .v-popover.open {
+  cursor: pointer;
+  color: #da5a47;
+}
+
+.tooltip {
+  max-width: 250px;
+}
+
+.info-circle {
+  fill: currentColor;
+  width: 18px;
+  height: 18px;
+  top: -1px;
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/* https://github.com/craftcms/cms/blob/37e3e20d9c8096d5489e16ebe0f9a46ae3eb5808/src/web/assets/pluginstore/src/sass/_tooltip.scss */
+
+.tooltip {
+  user-select: none;
+  pointer-events: none;
+  border-radius: 3px;
+  display: block !important;
+  z-index: 10000;
+  background: #fff;
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.4);
+  padding: 24px;
+}
+
+.tooltip .tooltip-arrow {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  position: absolute;
+  margin: 12px;
+  border-color: #fff;
+}
+
+.tooltip[x-placement^="top"] {
+  margin-bottom: 12px;
+}
+
+.tooltip[x-placement^="top"] .tooltip-arrow {
+  border-width: 12px 12px 0 12px;
+  border-left-color: transparent !important;
+  border-right-color: transparent !important;
+  border-bottom-color: transparent !important;
+  bottom: -12px;
+  left: calc(50% - 12px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.tooltip[x-placement^="bottom"] {
+  margin-top: 12px;
+}
+
+.tooltip[x-placement^="bottom"] .tooltip-arrow {
+  border-width: 0 12px 12px 12px;
+  border-left-color: transparent !important;
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+  top: -12px;
+  left: calc(50% - 12px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.tooltip[x-placement^="right"] {
+  margin-left: 12px;
+}
+
+.tooltip[x-placement^="right"] .tooltip-arrow {
+  border-width: 12px 12px 12px 0;
+  border-left-color: transparent !important;
+  border-top-color: transparent !important;
+  border-bottom-color: transparent !important;
+  left: -12px;
+  top: calc(50% - 12px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tooltip[x-placement^="left"] {
+  margin-right: 12px;
+}
+
+.tooltip[x-placement^="left"] .tooltip-arrow {
+  border-width: 12px 0 12px 12px;
+  border-top-color: transparent !important;
+  border-right-color: transparent !important;
+  border-bottom-color: transparent !important;
+  right: -12px;
+  top: calc(50% - 12px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tooltip[aria-hidden="true"] {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s, visibility 0.15s;
+}
+
+.tooltip[aria-hidden="false"] {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+</style>

--- a/editions.md
+++ b/editions.md
@@ -4,29 +4,16 @@ Craft Commerce comes in two editions, Lite and Pro. Both editions can be trialle
 
 ## Pro
 
-The Pro edition of Craft Commerce is designed for professional ecommerce sites. This would usually include a cart, which customers would update, and a multi-page checkout flow.
-
-The Pro edition has the following features that Lite does not:
-
-- Discount promotions, which include coupon codes and custom rules that can reduce the price of items in the cart based on things like minimum order quantity or minimum order price. 
-- Unlimited shipping methods that can have complex shipping rules.
-- Custom tax rules based on configurable multi-state or multi-country zones.
+The Pro edition of Craft Commerce is designed for professional ecommerce sites. This would usually include a cart customers can update and a multi-page checkout flow.
 
 ## Lite
 
-The Lite edition of Craft Commerce is designed for websites that just need the basics. For things like one-off product sales or subscriptions, where complex tax and shipping rules, promotion management, and shopping carts would be overkill.
+The Lite edition of Craft Commerce is designed for websites that need only the basics, where one-off product sales, subscriptions complex tax and shipping rules, promotion management, and shopping carts would be overkill.
 
-The Lite edition has the following limitations that the Pro edition does not:
+In the Lite edition of Craft Commerce only a single line item can exist in the cart. Whenever a customer adds something to the cart, it replaces whatever item was in the cart. If multiple items are added to the cart in a single request, only the last item that was submitted is added to the cart.
 
-- Only one purchasable can be ordered in a single payment transaction.
-- Orders can only be created by customers on the front end, not from the control panel.
-- Shipping costs can be configured in settings as fixed amounts per order, with no shipping method choices for the customer.
-- Tax costs can be configured as a fixed percentage of the order total, with no support for tax zones, or VAT ID validation.
-- Discount promotions, including coupon codes, are not available.
-- Custom adjusters can not be used to add additional costs and discounts.
+Although a cart always exists technically, a customer’s experience with Lite would probably not expose a cart UI on the front-end. For example, the customer probably shouldn't see a cart icon in the corner of the page like you would see in a traditional ecommerce design. A single ‘buy now’ button should be the call-to-action and the customer would go straight to providing email, shipping and payment information on a single screen.
 
-In the Lite edition of Craft Commerce only a single line item can exist in the cart. Whenever a customer adds something to the cart, it replaces whatever item was in the cart. If multiple items are added to the cart
-in a single request, only the last item that was submitted is added to the cart.
+## Feature Comparison
 
-Although a cart always exists technically, a customer’s experience with Lite would probably not expose a cart UI on the front-end. For example, the customer probably shouldn't see a cart icon in the corner
-of the page like you would see in a traditional ecommerce design. A single ‘buy now’ button should be the call-to-action and the customer would go straight to providing email, shipping and payment information on a single screen.
+<EditionComparison />

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "docs:sitemap": "vuepress-sitemap -H https://docs.craftcms.com/commerce/v2/"
   },
   "dependencies": {
-    "markdown-it-imsize": "^2.0.1"
+    "markdown-it-imsize": "^2.0.1",
+    "v-tooltip": "^2.0.3",
+    "vue-fragment": "^1.5.1"
   }
 }

--- a/product-types.md
+++ b/product-types.md
@@ -32,6 +32,18 @@ Defines what auto-generated SKUs should look like when a SKU field is submitted 
 How you access properties in the SKU format depends on whether the product type has variants. If the product type does not have multiple variants, use `{product}`. Otherwise, `{object}` will refer to the variant when the product type has multiple variants.
 :::
 
+Be sure to choose this carefully and avoid using the `id` property to ensure a unique SKU.
+
+Since `id` refers to the element’s ID and Craft may have many other elements, this won’t be sequential. If you’d rather generate a unique sequential number, consider using Craft’s [seq()](https://docs.craftcms.com/v3/dev/functions.html#seq) Twig function, which generates a next unique number based on the `name` parameter passed to it.
+
+The following example generates a sequential number, per variant, with the given product slug:
+
+```twig
+{{ object.product.slug }}-{{ seq(object.product.slug) }}
+```
+
+The resulting variant SKU might be something like `a-new-toga-001`, where `a-new-toga` is the product’s slug and `001` is the first sequential number based on that slug.
+
 ::: warning
 If a product type has an automatic SKU format, the SKU field is not shown for new variants. Once saved, the field will be displayed for editing.
 :::


### PR DESCRIPTION
Added a custom component for visually comparing edition features more clearly than standard tables would have allowed. Probably needs a few more edits for brevity and completeness.

<img width="808" alt="feature-comparison" src="https://user-images.githubusercontent.com/2488775/76242944-80979e00-6205-11ea-8e89-b62dcbcde395.png">