### PR TITLE
Document `getSalePrice()`.

### DIFF
--- a/.vuepress/config-en.js
+++ b/.vuepress/config-en.js
@@ -102,6 +102,7 @@ module.exports = {
                     'customer-address-management',
                     'twig-filters',
                     'loading-a-cart',
+                    'display-cart-items',
                     'making-payments',
                     'saving-payment-sources',
                     'subscription-templates',

--- a/display-cart-items.md
+++ b/display-cart-items.md
@@ -1,0 +1,43 @@
+# Display Cart Items
+
+At some point you’ll want to show a visitor their cart contents. There’s a more complex code sample in [the example templates](https://github.com/craftcms/commerce/blob/master/templates/shop/cart.html), but the basics are to get the cart, see whether it has any items, then loop through them to display each one’s `salePrice` and the cart `subtotal`.
+
+
+```twig
+{% set cart = craft.commerce.carts.cart %}
+
+<h1>Here’s what’s in your cart</h1>
+
+{% if cart.lineItems|length == 0 %}
+    <p>There aren’t any items in your cart.</p>
+{% else %}
+    <table>
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>Qty</th>
+                <th>Price</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in cart.lineItems %}
+                <tr>
+                    <td>{{ item.description }} <small>({{ item.sku }})</small></td>
+                    <td>{{ item.qty }}</td>
+                    <td>{{ item.salePrice|commerceCurrency(cart.currency) }}</td>
+                </tr>
+            {% endfor %}
+            <tr>
+                <td colspan="3">
+                    Cart Total: {{ cart.totalPrice|commerceCurrency(cart.currency) }}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+{% endif %}
+
+```
+
+::: tip
+You’ll most likely want to use `salePrice` so that the item’s price reflects any sales or promotions that should be applied. `price` refers to the value that was entered in the control panel.
+:::

--- a/purchasables.md
+++ b/purchasables.md
@@ -8,6 +8,15 @@ A purchasable:
 - implements [`craft\commerce\base\PurchasableInterface`](api:craft\commerce\base\PurchasableInterface)
 - should extend [`craft\commerce\base\Purchasable`](api:craft\commerce\base\Purchasable)
 
+If you’d like to introduce your own purchasable, it’s best to extend [the base Purchasable](api:craft\commerce\base\Purchasable) because you’ll automatically get...
+
+- `getSalePrice()` calculation
+- `getSales()` to see the details of each sale applied in that calculation
+- a standard Yii model that includes everything in `attributes()` and `extraFields()`
+- automatic `sku` validation
+
+You may alternatively choose to implement [PurchasableInterface](api:craft\commerce\base\PurchasableInterface), but you’ll need to handle these and any additional features yourself.
+
 ## Implementation
 
 To implement the Purchasable Interface, inherit from the base Purchasable and implement these methods:
@@ -23,6 +32,10 @@ This is the description of the purchasable. It would often be the title or name 
 ### `getPrice()`
 
 The default price of the item.
+
+### `getSalePrice()`
+
+The base price of the item, adjusted by any applicable sales.
 
 ### `getSku()`
 
@@ -79,7 +92,6 @@ For example, variants use this method to deduct stock.
 Returns the source param value for an element relation query, for use with promotions. For example, a sale promotion on a category needs to know if the purchasable is related.
 
 Defaults to the ID of the purchasable element, which would be sufficient for most purchasables.
-
 
 ## Purchasable deletion
 


### PR DESCRIPTION
Closes #18 in two parts:

- Adding `getSalePrice()` to the *Purchasables* page, with an introductory blurb recommending an extension of base purchasable and what you get compared to implementing PurchasableInterface.
- A new *Display Cart Items* page with a drastically simpler template example and reiterative tip about using `salePrice` instead of `price`.