### PR TITLE
Describe change in discount category match behavior.

### DIFF
--- a/upgrading.md
+++ b/upgrading.md
@@ -113,6 +113,6 @@ Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount
 
 ## Discount Category Matching
 
-The way discounts can match product categories has changed.
+Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount. Its options are “Source”, “Target”, and “Both”.
 
-Before Commerce 3, a category relationship field needed to be present for a product match. In Commerce 3 this is more flexible, as the categories may be selected and used as the source or the target for the match. You’ll need to evaluate any existing discounts to be ensure they’re are applied as intended.
+Commerce 2 required a relationship field to match products, using that as the source for discount matches. Existing discounts are migrated from Commerce 2 with “Source” selected, but it’s important to consider the relationship type as you create and work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied.

--- a/upgrading.md
+++ b/upgrading.md
@@ -115,4 +115,4 @@ Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount
 
 Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount or sale promotion. Its options are “Source”, “Target”, and “Either”. (See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.)
 
-Commerce 2 used discount categories as the “Source” for discount matches, and existing discounts are migrated from Commerce 2 with that option selected. It’s important to consider the relationship type as work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied and its default match type is “Either”.
+Commerce 2 used discount categories as the “Source” for discount matches, and existing discounts are migrated from Commerce 2 with that option selected. It’s important to consider the relationship type as you work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied and its default match type is “Either”.

--- a/upgrading.md
+++ b/upgrading.md
@@ -110,3 +110,9 @@ Use the table below to update each breaking change in your Twig templates.
 In order to improve compatibility with payment gateways and tax systems, custom adjuster types have been deprecated.
 
 Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount>, <api:craft\commerce\adjusters\Shipping>, or <api:craft\commerce\adjusters\Tax>.
+
+## Discount Category Matching
+
+The way discounts can match product categories has changed.
+
+Before Commerce 3, a category relationship field needed to be present for a product match. In Commerce 3 this is more flexible, as the categories may be selected and used as the source or the target for the match. You’ll need to evaluate any existing discounts to be ensure they’re are applied as intended.

--- a/upgrading.md
+++ b/upgrading.md
@@ -113,6 +113,6 @@ Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount
 
 ## Discount Category Matching
 
-Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount. Its options are “Source”, “Target”, and “Both”.
+Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount. Its options are “Source”, “Target”, and “Both”. (See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.)
 
-Commerce 2 required a relationship field to match products, using that as the source for discount matches. Existing discounts are migrated from Commerce 2 with “Source” selected, but it’s important to consider the relationship type as you create and work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied.
+Commerce 2 used discount categories as the source for discount matches. Existing discounts are migrated from Commerce 2 with “Source” selected, but it’s important to consider the relationship type as you create and work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied.

--- a/upgrading.md
+++ b/upgrading.md
@@ -115,4 +115,4 @@ Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount
 
 Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount or sale promotion. Its options are “Source”, “Target”, and “Either”. (See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.)
 
-Commerce 2 used discount categories as the “Source” for discount matches, and existing discounts are migrated from Commerce 2 with that option selected. It’s important to consider the relationship type as you work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied and its default match type is “Either”.
+Commerce 2 used discount categories as the “Source” for discount matches, and existing discounts are migrated from Commerce 2 with that option selected. It’s important to consider the relationship type as you work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts and sales are applied and its default match type is “Either”.

--- a/upgrading.md
+++ b/upgrading.md
@@ -113,6 +113,15 @@ Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount
 
 ## Discount Category Matching
 
-Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount. Its options are “Source”, “Target”, and “Both”. (See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.)
+Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount or sale promotion. 
+Its options are:
+ 
+- Source - The category relationship field is on the purchasable
+- Target - The purchasable relationship field is on the category
+- Either (Default) - The relationship field is on the purchasable or the category
 
-Commerce 2 used discount categories as the source for discount matches. Existing discounts are migrated from Commerce 2 with “Source” selected, but it’s important to consider the relationship type as you create and work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied.
+See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.
+
+Commerce 2 used discount categories as the 'Source' for discount matches.
+Existing discounts are migrated from Commerce 2 with “Source” selected, but it’s important to consider the 
+relationship type as you create and work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied.

--- a/upgrading.md
+++ b/upgrading.md
@@ -113,15 +113,6 @@ Custom adjusters must extend the included <api:craft\commerce\adjusters\Discount
 
 ## Discount Category Matching
 
-Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount or sale promotion. 
-Its options are:
- 
-- Source - The category relationship field is on the purchasable
-- Target - The purchasable relationship field is on the category
-- Either (Default) - The relationship field is on the purchasable or the category
+Commerce 3 adds a *Categories Relationship Type* field for choosing how designated purchasable categories may be used to match a discount or sale promotion. Its options are “Source”, “Target”, and “Either”. (See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.)
 
-See the Craft CMS [Relations](https://docs.craftcms.com/v3/relations.html) page for more on what each means.
-
-Commerce 2 used discount categories as the 'Source' for discount matches.
-Existing discounts are migrated from Commerce 2 with “Source” selected, but it’s important to consider the 
-relationship type as you create and work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied.
+Commerce 2 used discount categories as the “Source” for discount matches, and existing discounts are migrated from Commerce 2 with that option selected. It’s important to consider the relationship type as work with discounts in Commerce 3 since the *Categories Relationship Type* can impact how discounts are applied and its default match type is “Either”.


### PR DESCRIPTION
This describes the expanded options for applying category-based discounts in Commerce 3, now that [a migration](https://github.com/craftcms/commerce/pull/1565/commits/5bdc7514a564432e0bf40fd4f73b385f8ee76af3) will maintain the previous behavior for discounts that came from Commerce 2.