### PR TITLE
Note handling of `salePrice` in line item customizations.

### DIFF
--- a/events.md
+++ b/events.md
@@ -711,6 +711,10 @@ Event::on(
 );
 ```
 
+::: tip
+Don’t forget to set `salePrice` accordingly since it’s the amount that gets added to the cart.
+:::
+
 ### `createLineItem`
 
 The event that is triggered after a line item has been created from a purchasable.


### PR DESCRIPTION
This describes the change in how `salePrice` is handled from Commerce 2 to Commerce 3 when using the `populateLineItem` to customize line item pricing. Two new blurbs:

1. A lengthy note on the *Upgrading* page describing how the implicit `salePrice` value changes between Commerce versions and demonstrating how to update an event hook.
2. A quick callout with the `populateLineItem` documentation to reiterate the importance of addressing `salePrice` in customizations.